### PR TITLE
feat!: simplify implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # @chainsafe/pubkey-index-map
 
-Small napi-rs shim with an interface similar to `Map<Uint8Array, number>`
+Small napi-rs shim with an interface similar to `Map<Uint8Array, number>` but only for Uint8Arrays of length 48
 
 ```ts
 import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map"
 
 // instantiate a new map
 let map = new PubkeyIndexMap()
-// or instantiate a new map with more preallocated space
-map = PubkeyIndexMap.withInitialCapacity(1_000_000)
 
 const pubkey: Uint8Array = ...;
 const index: number = ...;

--- a/__test__/index.spec.mjs
+++ b/__test__/index.spec.mjs
@@ -7,9 +7,16 @@ test('PubkeyIndexMap basics', (t) => {
 
   t.is(map.size, 0)
 
-  const pubkey = Buffer.from('pubkey')
+  const pubkey = new Uint8Array(Buffer.alloc(48)).slice()
   const index = 42
   t.is(map.has(pubkey), false)
+
+  const p = new Uint8Array(1000)
+  t.is(map.has(p.subarray(0, 48)), false)
+  t.throws(() => map.has(Buffer.from('invalid')))
+  t.throws(() => map.get(Buffer.from('invalid')))
+  t.throws(() => map.set(Buffer.from('invalid'), 1))
+  t.throws(() => map.delete(Buffer.from('invalid')))
 
   // Add a pubkey
   map.set(pubkey, index)
@@ -18,12 +25,12 @@ test('PubkeyIndexMap basics', (t) => {
 
   t.is(map.size, 1)
   t.is(map.get(pubkey), index)
-  t.is(map.get(Buffer.from('pubkey')), index)
+  t.is(map.get(pubkey.slice()), index)
   t.is(map.has(pubkey), true)
-  t.is(map.has(Buffer.from('pubkey')), true)
+  t.is(map.has(pubkey.slice()), true)
 
   // Add another pubkey
-  const pubkey2 = Buffer.from('pubkey2')
+  const pubkey2 = new Uint8Array(Buffer.alloc(48, 1)).slice()
   const index2 = 43
   map.set(pubkey2, index2)
 
@@ -45,7 +52,7 @@ test('PubkeyIndexMap basics', (t) => {
   t.is(map.get(pubkey2), null)
 
   // Ensure different instances of the same pubkey are treated as the same
-  const pubkey3 = Buffer.from('pubkey')
+  const pubkey3 = pubkey.slice()
   const index3 = 44
   map.set(pubkey, index)
   map.set(pubkey3, index3)

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,8 +5,7 @@
 
 export class PubkeyIndexMap {
   constructor()
-  static withInitialCapacity(capacity: number): PubkeyIndexMap
-  set(key: Uint8Array, value: number): void
+  set(key: Uint8Array, value: number): number | null
   get(key: Uint8Array): number | null
   has(key: Uint8Array): boolean
   delete(key: Uint8Array): number | null


### PR DESCRIPTION
The original goal of this repo is to explore more memory-efficient pubkey to index maps.
To that end, storing `Uint8Array`s directly in the map is not feasible due to the large memory overhead of each instance.

So instead, store fixed-length arrays (`[u8; 48]`) as keys.